### PR TITLE
QGrid - improve date format when exporting to excel

### DIFF
--- a/src/main/studio/kdb/K.java
+++ b/src/main/studio/kdb/K.java
@@ -5,6 +5,7 @@ import java.io.OutputStream;
 import java.lang.reflect.Array;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
@@ -753,6 +754,8 @@ public class K {
     }
 
     public static class KDate extends KBase {
+        private static final DateFormat DEFAULT_DATE_FORMAT = DateFormat.getDateInstance(DateFormat.DEFAULT, Locale.getDefault());
+
         public String getDataType() {
             return "Date";
         }
@@ -770,13 +773,13 @@ public class K {
 
         public String toString(boolean showType) {
             if (isNull())
-                return "0Nd";
+                return showType ? "0Nd" :"0N";
             else if (date == Integer.MAX_VALUE)
-                return "0Wd";
+                return showType ? "0Wd" : "0W";
             else if (date == -Integer.MAX_VALUE)
-                return "-0Wd";
+                return showType ? "-0Wd" : "-0W";
             else
-                return sd("yyyy.MM.dd", new Date(86400000L * (date + 10957)));
+                return sd("yyyy.MM.dd", toDate());
         }
 
         public void toString(LimitedWriter w, boolean showType) throws IOException {
@@ -785,6 +788,18 @@ public class K {
 
         public Date toDate() {
             return new Date(86400000L * (date + 10957));
+        }
+
+        public String toExcelDate() {
+            if (isNull())
+                return "0N";
+            else if (date == Integer.MAX_VALUE)
+                return "0W";
+            else if (date == -Integer.MAX_VALUE)
+                return "-0W";
+            else
+                return DEFAULT_DATE_FORMAT.format(toDate());
+
         }
     }
 
@@ -832,14 +847,15 @@ public class K {
         }
 
         public String toString(boolean showType) {
-            if (isNull())
-                return "0Nt";
-            else if (time == Integer.MAX_VALUE)
-                return "0Wt";
-            else if (time == -Integer.MAX_VALUE)
-                return "-0Wt";
-            else
+            if (isNull()) {
+                return showType ? "0Nt" : "0N";
+            } else if (time == Integer.MAX_VALUE) {
+                return showType ? "0Wt" : "0W";
+            } else if(time ==-Integer.MAX_VALUE){
+                return showType ? "-0Wt" : "-0W";
+            }  else {
                 return sd("HH:mm:ss.SSS", new Time(time));
+            }
         }
 
         public void toString(LimitedWriter w, boolean showType) throws IOException {
@@ -906,13 +922,13 @@ public class K {
         }
 
         public String toString(boolean showType) {
-            if (isNull())
-                return "0Np";
-            else if (time == Long.MAX_VALUE)
-                return "0Wp";
-            else if (time == -Long.MAX_VALUE)
-                return "-0Wp";
-            else {
+            if (isNull()) {
+                return showType ? "0Np" : "0N";
+            } else if (time == Long.MAX_VALUE) {
+                return showType ? "0Wp" : "0W";
+            } else if (time == -Long.MAX_VALUE) {
+                return showType ? "-0Wp" : "-0W";
+            } else {
                 Timestamp ts = toTimestamp();
                 return sd("yyyy.MM.dd HH:mm:ss.", ts) + nsFormatter.format(ts.getNanos());
             }
@@ -1149,13 +1165,13 @@ public class K {
         }
 
         public String toString(boolean showType) {
-            if (isNull())
-                return "0Nn";
-            else if (j == Long.MAX_VALUE)
-                return "0Wn";
-            else if (j == -Long.MAX_VALUE)
-                return "-0Wn";
-            else {
+            if (isNull()) {
+                return showType ? "0Nn" : "0N";
+            } else if (j == Long.MAX_VALUE) {
+                return showType ? "0Wn" : "0W";
+            } else if (j == -Long.MAX_VALUE) {
+                return showType ? "-0Wn" : "-0W";
+            } else {
                 String s = "";
                 long jj = j;
                 if (jj < 0) {
@@ -1707,6 +1723,10 @@ public class K {
                         w.write(" ");
                     w.write(at(i).toString(false));
                 }
+
+                if (showType) {
+                    w.write('p');
+                }
             }
         }
     }
@@ -1735,6 +1755,10 @@ public class K {
                     if (i > 0)
                         w.write(" ");
                     w.write(at(i).toString(false));
+                }
+
+                if (showType) {
+                    w.write('n');
                 }
             }
         }

--- a/src/main/studio/ui/QGrid.java
+++ b/src/main/studio/ui/QGrid.java
@@ -245,8 +245,13 @@ public class QGrid extends JPanel {
                             sb.append("\"");
 
                         K.KBase b = (K.KBase) table.getValueAt(rowsselected[row], colsselected[col]);
-                        if (!b.isNull())
-                            sb.append(b.toString(false));
+                        if (!b.isNull()) {
+                            if (b instanceof K.KDate) {
+                                sb.append(((K.KDate) b).toExcelDate());
+                            } else {
+                                sb.append(b.toString(false));
+                            }
+                        }
                         if (symColumn)
                             sb.append("\"");
                         if (col < numcols - 1)

--- a/src/test/studio/kdb/KTest.java
+++ b/src/test/studio/kdb/KTest.java
@@ -121,7 +121,6 @@ public class KTest {
         return baseVector;
     }
 
-
     @Test
     public void testIntegerToString() throws Exception {
         check(new K.KInteger(-123), "-123", "-123i");
@@ -255,37 +254,37 @@ public class KTest {
     public void testTimestampToString() throws Exception {
         check(new K.KTimestamp(-123456789), "1999.12.31 23:59:59.876543211", "1999.12.31 23:59:59.876543211");
         check(new K.KTimestamp(123456), "2000.01.01 00:00:00.000123456", "2000.01.01 00:00:00.000123456");
-        check(new K.KTimestamp(-Long.MAX_VALUE), "-0Wp", "-0Wp");
-        check(new K.KTimestamp(Long. MAX_VALUE), "0Wp", "0Wp");
-        check(new K.KTimestamp(Long.MIN_VALUE), "0Np", "0Np");
+        check(new K.KTimestamp(-Long.MAX_VALUE), "-0W", "-0Wp");
+        check(new K.KTimestamp(Long. MAX_VALUE), "0W", "0Wp");
+        check(new K.KTimestamp(Long.MIN_VALUE), "0N", "0Np");
 
-        check(vector(K.KTimestampVector.class, -10, 10, 3), "1999.12.31 23:59:59.999999990 2000.01.01 00:00:00.000000010 2000.01.01 00:00:00.000000003", "1999.12.31 23:59:59.999999990 2000.01.01 00:00:00.000000010 2000.01.01 00:00:00.000000003");
+        check(vector(K.KTimestampVector.class, -10, 10, 3), "1999.12.31 23:59:59.999999990 2000.01.01 00:00:00.000000010 2000.01.01 00:00:00.000000003", "1999.12.31 23:59:59.999999990 2000.01.01 00:00:00.000000010 2000.01.01 00:00:00.000000003p");
         check(vector(K.KTimestampVector.class), "`timestamp$()", "`timestamp$()");
-        check(vector(K.KTimestampVector.class, 0), "enlist 2000.01.01 00:00:00.000000000", "enlist 2000.01.01 00:00:00.000000000");
-        check(vector(K.KTimestampVector.class, 5, Long.MIN_VALUE, Long.MAX_VALUE, -Long.MAX_VALUE), "2000.01.01 00:00:00.000000005 0Np 0Wp -0Wp", "2000.01.01 00:00:00.000000005 0Np 0Wp -0Wp");
+        check(vector(K.KTimestampVector.class, 0), "enlist 2000.01.01 00:00:00.000000000", "enlist 2000.01.01 00:00:00.000000000p");
+        check(vector(K.KTimestampVector.class, 5, Long.MIN_VALUE, Long.MAX_VALUE, -Long.MAX_VALUE), "2000.01.01 00:00:00.000000005 0N 0W -0W", "2000.01.01 00:00:00.000000005 0N 0W -0Wp");
     }
 
     @Test
     public void testTimespanToString() throws Exception {
         check(new K.KTimespan(-765432123456789L), "-8D20:37:12.123456789", "-8D20:37:12.123456789");
         check(new K.KTimespan(123456), "00:00:00.000123456", "00:00:00.000123456");
-        check(new K.KTimespan(-Long.MAX_VALUE), "-0Wn", "-0Wn");
-        check(new K.KTimespan(Long. MAX_VALUE), "0Wn", "0Wn");
-        check(new K.KTimespan(Long.MIN_VALUE), "0Nn", "0Nn");
+        check(new K.KTimespan(-Long.MAX_VALUE), "-0W", "-0Wn");
+        check(new K.KTimespan(Long. MAX_VALUE), "0W", "0Wn");
+        check(new K.KTimespan(Long.MIN_VALUE), "0N", "0Nn");
 
-        check(vector(K.KTimespanVector.class, -10, 10, 3), "-00:00:00.000000010 00:00:00.000000010 00:00:00.000000003", "-00:00:00.000000010 00:00:00.000000010 00:00:00.000000003");
+        check(vector(K.KTimespanVector.class, -10, 10, 3), "-00:00:00.000000010 00:00:00.000000010 00:00:00.000000003", "-00:00:00.000000010 00:00:00.000000010 00:00:00.000000003n");
         check(vector(K.KTimespanVector.class), "`timespan$()", "`timespan$()");
-        check(vector(K.KTimespanVector.class, 0), "enlist 00:00:00.000000000", "enlist 00:00:00.000000000");
-        check(vector(K.KTimespanVector.class, 5, Long.MIN_VALUE, Long.MAX_VALUE, -Long.MAX_VALUE), "00:00:00.000000005 0Nn 0Wn -0Wn", "00:00:00.000000005 0Nn 0Wn -0Wn");
+        check(vector(K.KTimespanVector.class, 0), "enlist 00:00:00.000000000", "enlist 00:00:00.000000000n");
+        check(vector(K.KTimespanVector.class, 5, Long.MIN_VALUE, Long.MAX_VALUE, -Long.MAX_VALUE), "00:00:00.000000005 0N 0W -0W", "00:00:00.000000005 0N 0W -0Wn");
     }
 
     @Test
     public void testDateToString() throws Exception {
         check(new K.KDate(-1234), "1996.08.15", "1996.08.15");
         check(new K.KDate(123456), "2338.01.05", "2338.01.05");
-        check(new K.KDate(-Integer.MAX_VALUE), "-0Wd", "-0Wd");
-        check(new K.KDate(Integer. MAX_VALUE), "0Wd", "0Wd");
-        check(new K.KDate(Integer.MIN_VALUE), "0Nd", "0Nd");
+        check(new K.KDate(-Integer.MAX_VALUE), "-0W", "-0Wd");
+        check(new K.KDate(Integer. MAX_VALUE), "0W", "0Wd");
+        check(new K.KDate(Integer.MIN_VALUE), "0N", "0Nd");
 
         check(vector(K.KDateVector.class, -10, 10, 3), "1999.12.22 2000.01.11 2000.01.04", "1999.12.22 2000.01.11 2000.01.04");
         check(vector(K.KDateVector.class), "`date$()", "`date$()");
@@ -298,9 +297,9 @@ public class KTest {
         check(new K.KTime(-1234567890), "17:03:52.110", "17:03:52.110");
         check(new K.KTime(323456789), "17:50:56.789", "17:50:56.789");
 
-        check(new K.KTime(-Integer.MAX_VALUE), "-0Wt", "-0Wt");
-        check(new K.KTime(Integer. MAX_VALUE), "0Wt", "0Wt");
-        check(new K.KTime(Integer.MIN_VALUE), "0Nt", "0Nt");
+        check(new K.KTime(-Integer.MAX_VALUE), "-0W", "-0Wt");
+        check(new K.KTime(Integer. MAX_VALUE), "0W", "0Wt");
+        check(new K.KTime(Integer.MIN_VALUE), "0N", "0Nt");
 
         check(vector(K.KTimeVector.class, -10, 10, 3), "23:59:59.990 00:00:00.010 00:00:00.003", "23:59:59.990 00:00:00.010 00:00:00.003");
         check(vector(K.KTimeVector.class), "`time$()", "`time$()");


### PR DESCRIPTION
- QGrid - improve date format when exporting to excel
- K.java - Make toString more consistent for KDate, KTimestamp, KTimespan, KTime

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.