### PR TITLE
Fix NPE in replace all

### DIFF
--- a/src/main/org/netbeans/editor/BaseDocumentEvent.java
+++ b/src/main/org/netbeans/editor/BaseDocumentEvent.java
@@ -508,11 +508,19 @@ public class BaseDocumentEvent extends AbstractDocument.DefaultDocumentEvent {
     }
 
     public int getOffset() {
-        return ((DocumentContent.Edit)lastEdit()).getOffset();
+        if (lastEdit() != null) {
+            return ((DocumentContent.Edit) lastEdit()).getOffset();
+        } else {
+            return super.getOffset();
+        }
     }
 
     public int getLength() {
-        return ((DocumentContent.Edit)lastEdit()).getLength();
+        if (lastEdit() != null) {
+            return ((DocumentContent.Edit) lastEdit()).getLength();
+        } else {
+            return super.getLength();
+        }
     }
 
     /** Edit describing the change of the document draw-layers */


### PR DESCRIPTION
Getting this NPE when clicking on "replace all"

```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException: Cannot invoke "org.netbeans.editor.DocumentContent$Edit.getOffset()" because the return value of "org.netbeans.editor.BaseDocumentEvent.lastEdit()" is null
	at org.netbeans.editor.BaseDocumentEvent.getOffset(BaseDocumentEvent.java:511)
	at org.netbeans.editor.LeafView.changedUpdate(LeafView.java:463)
	at org.netbeans.editor.BaseTextUI$RootView.changedUpdate(BaseTextUI.java:722)
	at org.netbeans.editor.BaseTextUI.changedUpdate(BaseTextUI.java:472)
	at java.desktop/javax.swing.text.AbstractDocument.fireChangedUpdate(AbstractDocument.java:232)
	at org.netbeans.editor.BaseDocument.fireChangedUpdate(BaseDocument.java:1028)
	at org.netbeans.editor.BaseDocument.findSupportChange(BaseDocument.java:299)
	at org.netbeans.editor.BaseDocument.access$000(BaseDocument.java:38)
	at org.netbeans.editor.BaseDocument$1.propertyChange(BaseDocument.java:270)
	at org.netbeans.editor.WeakPropertyChangeSupport.firePropertyChange(WeakPropertyChangeSupport.java:98)
	at org.netbeans.editor.FindSupport.firePropertyChange(FindSupport.java:628)
	at org.netbeans.editor.FindSupport.putFindProperties(FindSupport.java:222)
	at org.netbeans.editor.ext.FindDialogSupport$FindPanel.save(FindDialogSupport.java:467)
	at org.netbeans.editor.ext.FindDialogSupport.actionPerformed(FindDialogSupport.java:248)
	at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1972)
	at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2313)
	at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:405)
	at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
```

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.