### PR TITLE
connection

### DIFF
--- a/src/main/kx/c.java
+++ b/src/main/kx/c.java
@@ -112,10 +112,10 @@ public class c {
         closed = false;
     }
 
-    private String host;
-    private int port;
-    private String up;
-    private boolean useTLS;
+    private final String host;
+    private final int port;
+    private final String up;
+    private final boolean useTLS;
 
     public c(String h, int p, String u, boolean useTLS) {
         host = h;

--- a/src/main/studio/core/Credentials.java
+++ b/src/main/studio/core/Credentials.java
@@ -1,8 +1,8 @@
 package studio.core;
 
 public class Credentials {
-    private String username;
-    private String password;
+    private final String username;
+    private final String password;
 
     public Credentials(String username, String password) {
         this.username = username;

--- a/src/main/studio/core/IAuthenticationMechanism.java
+++ b/src/main/studio/core/IAuthenticationMechanism.java
@@ -3,11 +3,15 @@ package studio.core;
 import java.util.Properties;
 
 public interface IAuthenticationMechanism {
-    public String getMechanismName();
+    String getMechanismName();
 
-    public String[] getMechanismPropertyNames();
+    String[] getMechanismPropertyNames();
 
-    public void setProperties(Properties props);
+    void setProperties(Properties props);
 
-    public Credentials getCredentials();
+    Credentials getCredentials();
+
+    default long getExpiration() {
+        return Long.MAX_VALUE;
+    }
 }

--- a/src/main/studio/kdb/ConnectionPool.java
+++ b/src/main/studio/kdb/ConnectionPool.java
@@ -1,95 +1,114 @@
 package studio.kdb;
 
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import studio.core.AuthenticationManager;
 import studio.core.Credentials;
 import studio.core.IAuthenticationMechanism;
-import java.util.*;
-import java.io.IOException;
-import kx.c.K4Exception;
 
 public class ConnectionPool {
 
     private static final Logger log = LogManager.getLogger();
 
     private final static ConnectionPool instance = new ConnectionPool();
-    private final Map<Server,List<kx.c>> freeMap = new HashMap<>();
-    private final Map<Server,List<kx.c>> busyMap = new HashMap<>();
+    private final Map<Server, List<Connection>> freeMap = new HashMap<>();
+    private final Map<Server, List<Connection>> busyMap = new HashMap<>();
 
     public static ConnectionPool getInstance() {
         return instance;
     }
 
-    private ConnectionPool() {}
-
-    public synchronized void purge(Server s) {
-        List<kx.c> list = freeMap.computeIfAbsent(s, k -> new LinkedList<>());
-        for (kx.c c: list) {
-            c.close();
-        }
-        list.clear();
-        busyMap.put(s,new LinkedList<>());
+    private ConnectionPool() {
     }
 
-    public synchronized kx.c leaseConnection(Server s) throws IOException, K4Exception {
-        List<kx.c> list =  freeMap.computeIfAbsent(s, k -> new LinkedList<>());
-        List<kx.c> dead = new LinkedList<>();
+    public synchronized void purge(Server s) {
+        List<Connection> list = freeMap.computeIfAbsent(s, k -> new LinkedList<>());
+        for (Connection c : list) {
+            c.c.close();
+        }
+        list.clear();
+        busyMap.put(s, new LinkedList<>());
+    }
 
-        kx.c c = null;
-        for (kx.c value : list) {
-            if (!value.isClosed()) {
-                c = value;
+    public synchronized kx.c leaseConnection(Server s) {
+        List<Connection> list = freeMap.computeIfAbsent(s, k -> new LinkedList<>());
+        List<Connection> dead = new LinkedList<>();
+
+        Connection connection = null;
+        long now = System.currentTimeMillis();
+        for (Connection value : list) {
+            if (!value.c.isClosed() && now < value.expiration) {
+                connection = value;
                 break;
             }
-            dead.add(c);
+            dead.add(value);
         }
 
         list.removeAll(dead);
 
-        if (c == null) {
+        if (connection == null) {
             try {
+                kx.c c;
                 Class<?> clazz = AuthenticationManager.getInstance().lookup(s.getAuthenticationMechanism());
-                IAuthenticationMechanism authenticationMechanism = (IAuthenticationMechanism) clazz.newInstance();
+                IAuthenticationMechanism authenticationMechanism = (IAuthenticationMechanism) clazz.getDeclaredConstructor().newInstance();
 
                 authenticationMechanism.setProperties(s.getAsProperties());
                 Credentials credentials = authenticationMechanism.getCredentials();
                 if (credentials.getUsername().length() > 0) {
                     String p = credentials.getPassword();
-                    c = new kx.c(s.getHost(), s.getPort(), credentials.getUsername() + ((p.length() == 0) ? "" : ":" + p), s.getUseTLS());
+                    c = new kx.c(s.getHost(), s.getPort(),
+                        credentials.getUsername() + ((p.length() == 0) ? "" : ":" + p),
+                        s.getUseTLS());
                 } else {
                     c = new kx.c(s.getHost(), s.getPort(), "", s.getUseTLS());
                 }
                 c.setEncoding(Config.getInstance().getEncoding());
-            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException ex) {
+                connection = new Connection(c, authenticationMechanism.getExpiration());
+            } catch (Exception ex) {
                 log.error("Failed to initialize connection", ex);
                 return null;
             }
         } else {
-            list.remove(c);
+            list.remove(connection);
         }
 
         list = busyMap.computeIfAbsent(s, k -> new LinkedList<>());
-        list.add(c);
+        list.add(connection);
 
-        return c;
+        return connection.c;
     }
 
-    public synchronized void freeConnection(Server s,kx.c c) {
-        if (c == null) return;
+    public synchronized void freeConnection(Server s, kx.c c) {
+        if (c == null) {
+            return;
+        }
 
-        List<kx.c> list = busyMap.computeIfAbsent(s, k -> new LinkedList<>());
+        List<Connection> list = busyMap.computeIfAbsent(s, k -> new LinkedList<>());
 
-        // If c not in our busy list it has been purged, so close it
-        if (!list.remove(c))
+        Connection connection = list.stream().filter(o -> o.c == c).findFirst().orElse(null);
+        if (connection == null) { // If c not in our busy list it has been purged, so close it
             c.close();
-
-        if (!c.isClosed()) {
+        } else if (!c.isClosed()) {
             list = freeMap.get(s);
-            if (list == null)
+            if (list == null) {
                 c.close();
-            else
-                list.add(c);
+            } else {
+                list.add(connection);
+            }
+        }
+    }
+
+    private static class Connection {
+        final kx.c c;
+        final long expiration;
+
+        private Connection(kx.c c, long expiration) {
+            this.c = c;
+            this.expiration = expiration;
         }
     }
 


### PR DESCRIPTION
The current implementation (of keeping connection alive for a long time) causes issues with Morgan's kerberos connection logic as the token generated has an expiration.

Current workaround is to open the Server dialog and click ok, which ends up calling `ConnectionPool.purge`.



THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.
