### PR TITLE
config and log folder can be set with KDBSTUDIO_CONFIG_HOME variable

### DIFF
--- a/src/main/log4j2.xml
+++ b/src/main/log4j2.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="warn">
+<Configuration status="warn" packages="studio.utils.log4j">
     <Properties>
-        <!-- Reference to the folder with Config properties - see Config class  -->
-        <Property name="baseFolder">${sys:user.home}/.studioforkdb${sys:log4j.studio.envSuffix:-}/log</Property>
+        <!-- studiobase lookup plugin is defined in studio.utils.log4j.EnvConfig -->
+        <Property name="baseFolder">${studiobase:log}</Property>
     </Properties>
 
     <Appenders>

--- a/src/main/studio/core/Studio.java
+++ b/src/main/studio/core/Studio.java
@@ -30,14 +30,6 @@ public class Studio {
     private static boolean macOSSystemMenu = false;
 
     private static void initLogger() {
-        String env = System.getProperty("env");
-        if (env != null) {
-            log.info("Set environment to {}", env);
-            System.setProperty("log4j.studio.envSuffix", "/" + env);
-            ((org.apache.logging.log4j.core.LoggerContext) LogManager.getContext(false)).reconfigure();
-            Config.setEnvironment(env);
-        }
-
         PrintStream stdoutStream = IoBuilder.forLogger("stdout").setLevel(Level.INFO).buildPrintStream();
         PrintStream stderrStream = IoBuilder.forLogger("stderr").setLevel(Level.ERROR).buildPrintStream();
         System.setOut(stdoutStream);

--- a/src/main/studio/ui/HelpDialog.java
+++ b/src/main/studio/ui/HelpDialog.java
@@ -1,8 +1,8 @@
 package studio.ui;
 
-import studio.kdb.Config;
 import studio.kdb.Lm;
 import studio.utils.BrowserLaunch;
+import studio.utils.log4j.EnvConfig;
 
 import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
@@ -10,13 +10,11 @@ import javax.swing.event.HyperlinkListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.text.SimpleDateFormat;
-import java.util.TimeZone;
 
 public class HelpDialog extends JDialog {
     public HelpDialog(JFrame parent) {
         super(parent, "Studio for kdb+");
-        String env = Config.getEnvironment();
+        String env = EnvConfig.getEnvironment();
         final JEditorPane jep = new JEditorPane("text/html",
                 "<html><head><title>Studio for kdb+</title></head><body><h1>Studio for kdb+</h1>"
                         + "<p>"

--- a/src/main/studio/ui/StudioPanel.java
+++ b/src/main/studio/ui/StudioPanel.java
@@ -19,6 +19,7 @@ import studio.ui.dndtabbedpane.DraggableTabbedPane;
 import studio.ui.rstextarea.FindReplaceAction;
 import studio.ui.rstextarea.RSTextAreaFactory;
 import studio.utils.*;
+import studio.utils.log4j.EnvConfig;
 
 import javax.swing.FocusManager;
 import javax.swing.*;
@@ -153,7 +154,7 @@ public class StudioPanel extends JPanel implements WindowListener {
 
         if (! loading) {
             Server server = editor.getServer();
-            String env = Config.getEnvironment();
+            String env = EnvConfig.getEnvironment();
             String frameTitle = editor.getTitle() + (editor.isModified() ? " (not saved) " : "") + (server != null ? " @" + server.toString() : "") + " Studio for kdb+ " + Lm.version + (env == null ? "" : " [" + env + "]");
             if (!frameTitle.equals(frame.getTitle())) {
                 frame.setTitle(frameTitle);

--- a/src/main/studio/utils/WindowsAppUserMode.java
+++ b/src/main/studio/utils/WindowsAppUserMode.java
@@ -5,16 +5,16 @@ import com.sun.jna.NativeLong;
 import com.sun.jna.WString;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import studio.kdb.Config;
 import studio.kdb.Lm;
 import studio.ui.Util;
+import studio.utils.log4j.EnvConfig;
 
 public class WindowsAppUserMode {
     private static final Logger log = LogManager.getLogger();
 
     private final static boolean initialized = init();
 
-    private final static String mainID = "kdbStudioAppID" + Config.getEnvironment() + Lm.version;
+    private final static String mainID = "kdbStudioAppID" + EnvConfig.getEnvironment() + Lm.version;
     private final static String chartID = mainID + "Chart";
 
     private static boolean init() {

--- a/src/main/studio/utils/log4j/EnvConfig.java
+++ b/src/main/studio/utils/log4j/EnvConfig.java
@@ -1,0 +1,47 @@
+package studio.utils.log4j;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.lookup.StrLookup;
+
+@Plugin(name="studiobase", category = StrLookup.CATEGORY)
+public class EnvConfig implements StrLookup {
+
+    private final static String environment = System.getProperty("env");
+    private final static String homeFolder = getValue("KDBSTUDIO_CONFIG_HOME", System.getProperty("user.home") + "/.studioforkdb");
+
+    public static String getEnvironment() {
+        return environment;
+    }
+
+    public static String getBaseFolder(String env) {
+        return env == null ? homeFolder : homeFolder + "/" + env;
+    }
+
+    public static String getBaseFolder() {
+        return getBaseFolder(environment);
+    }
+
+    public static String getFilepath(String env, String filename) {
+        return getBaseFolder(env) + "/" + filename;
+    }
+
+    public static String getFilepath(String filename) {
+        return getFilepath(environment, filename);
+    }
+
+    private static String getValue(String key, String defaultValue) {
+        String value = System.getProperty(key, System.getenv(key));
+        return value == null ? defaultValue : value;
+    }
+
+    @Override
+    public String lookup(String key) {
+        return getFilepath(key);
+    }
+
+    @Override
+    public String lookup(LogEvent event, String key) {
+        return lookup(key);
+    }
+}

--- a/src/test/studio/kdb/ConfigTest.java
+++ b/src/test/studio/kdb/ConfigTest.java
@@ -24,7 +24,7 @@ public class ConfigTest {
     public void init() throws IOException {
         tmpFile = File.createTempFile("studioforkdb", ".tmp");
         tmpFile.deleteOnExit();
-        config = Config.getByFilename(tmpFile.getPath());
+        config = new Config(tmpFile.getPath());
         System.out.println("temp file " + tmpFile.getPath());
 
         server = new Server("testServer", "localhost",1111,
@@ -77,7 +77,7 @@ public class ConfigTest {
         assertEquals(value+1, config.getResultTabsCount());
         assertEquals(value, config1.getResultTabsCount());
 
-        assertEquals(value+1, Config.getByFilename(tmpFile.getPath()).getResultTabsCount());
+        assertEquals(value+1, new Config(tmpFile.getPath()).getResultTabsCount());
     }
 
     @Test
@@ -148,7 +148,7 @@ public class ConfigTest {
         properties.store(out, null);
         out.close();
 
-        return Config.getByFilename(newFile.getPath());
+        return new Config(newFile.getPath());
     } 
     
     private Config copyConfig(Config config, Consumer<Properties> propsModification) throws IOException {


### PR DESCRIPTION
(cherry picked from commit d6645dc0c2dcdc7199deb476951d40659742819e)

This is to allow to configure the folder with log and configuration files (studio.properties and workspace.properties). Default location is $HOME/.studioforkdb folder. The folder can be overridden with KDBSTUDIO_CONFIG_HOME variable (either by environment variable or java system property - the latter has precedence). 

Also it was preserved possibility to pass java system property env which will be an extra folder under the config folder. The property is useful if a user wants to start several version of the kdbStudio. So logs and configuration are not clashed between environments.