### PR TITLE
use new rsyntaxtextarea, add test for replaceAll

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-iostreams', version: '2.17.1'
-    implementation group: 'com.fifesoft', name: 'rsyntaxtextarea', version: '3.1.3'
+    implementation group: 'com.fifesoft', name: 'rsyntaxtextarea', version: '3.2.0'
     implementation group: 'org.jfree', name: 'jfreechart', version: '1.5.3'
     implementation group: 'org.apache.poi', name: 'poi', version: '5.1.0'
     implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.1.0'

--- a/src/main/studio/ui/SearchPanel.java
+++ b/src/main/studio/ui/SearchPanel.java
@@ -53,7 +53,9 @@ public class SearchPanel extends JPanel {
         tglCaseSensitive = getButton(Util.SEARCH_CASE_SENSITIVE_SHADED_ICON, Util.SEARCH_CASE_SENSITIVE_ICON, "Case sensitive");
 
         txtFind = new JTextField();
+        txtFind.setName("txtFind");
         txtReplace = new JTextField();
+        txtReplace.setName("txtReplace");
 
         JLabel lblFind = new JLabel("Find: ");
         lblReplace = new JLabel("Replace: " );
@@ -70,6 +72,7 @@ public class SearchPanel extends JPanel {
         JButton btnMarkAll = new JButton(markAllAction);
         btnReplace = new JButton(replaceAction);
         btnReplaceAll = new JButton(replaceAllAction);
+        btnReplaceAll.setName("btnReplaceAll");
         JButton btnClose = new JButton(closeAction);
 
         ActionMap am = txtFind.getActionMap();

--- a/src/test-integration/studio/StudioTest.java
+++ b/src/test-integration/studio/StudioTest.java
@@ -56,6 +56,11 @@ public class StudioTest extends AssertJSwingJUnitTestCase {
         tb.requireEmpty();
         window.button("redo").click();
         tb.requireText("abc\ndef");
+        tb.pressAndReleaseKey(KeyPressInfo.keyCode(KeyEvent.VK_R).modifiers(KeyEvent.CTRL_MASK));
+        window.textBox("txtFind").setText("a");
+        window.textBox("txtReplace").setText("aa"); //replacement text should contain the find text as a substring
+        window.button("btnReplaceAll").click();     //this was an infinite loop with rsyntaxtextarea 3.1.3
+        tb.requireText("aabc\ndef");
     }
 
 }


### PR DESCRIPTION
Apparently the new version of rsyntaxtextarea no longer has the infinite loop.
Fixes #106 

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.
