### PR TITLE
delete_next_word

### DIFF
--- a/src/main/studio/ui/rstextarea/DeleteNextWordAction.java
+++ b/src/main/studio/ui/rstextarea/DeleteNextWordAction.java
@@ -1,0 +1,39 @@
+package studio.ui.rstextarea;
+
+import java.awt.event.ActionEvent;
+import javax.swing.UIManager;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Utilities;
+import org.fife.ui.rtextarea.RTextArea;
+import org.fife.ui.rtextarea.RecordableTextAction;
+
+public class DeleteNextWordAction extends RecordableTextAction {
+
+    public static final String deleteNextWordAction = "kdbStudio.deleteNextWordAction";
+
+    public DeleteNextWordAction() {
+        super(deleteNextWordAction);
+    }
+
+    @Override
+    public void actionPerformedImpl(ActionEvent e, RTextArea textArea) {
+        if (!textArea.isEditable() || !textArea.isEnabled()) {
+            UIManager.getLookAndFeel().provideErrorFeedback(textArea);
+            return;
+        }
+        try {
+            int start = textArea.getSelectionStart();
+            int end = Utilities.getNextWord(textArea, start);
+            if (end > start) {
+                textArea.getDocument().remove(start, end - start);
+            }
+        } catch (BadLocationException ex) {
+            UIManager.getLookAndFeel().provideErrorFeedback(textArea);
+        }
+    }
+
+    @Override
+    public String getMacroID() {
+        return getName();
+    }
+}

--- a/src/main/studio/ui/rstextarea/RSTextAreaFactory.java
+++ b/src/main/studio/ui/rstextarea/RSTextAreaFactory.java
@@ -1,5 +1,7 @@
 package studio.ui.rstextarea;
 
+import static studio.ui.rstextarea.DeleteNextWordAction.deleteNextWordAction;
+
 import org.fife.ui.rsyntaxtextarea.*;
 import org.fife.ui.rsyntaxtextarea.folding.CurlyFoldParser;
 import org.fife.ui.rsyntaxtextarea.folding.FoldParserManager;
@@ -27,6 +29,7 @@ public class RSTextAreaFactory {
     public static final String rstaCutAsStyledTextAction = "kdbStudio.rstaCutAsStyledTextAction";
     public static final String rstaCopyAsStyledTextAction = "kdbStudio.rstaCopyAsStyledTextAction";
 
+
     private static final ActionMap actionMap;
 
     static {
@@ -40,6 +43,7 @@ public class RSTextAreaFactory {
         actions.add(new FindNextAction(true));
         actions.add(new FindNextAction(false));
         actions.add(new HideSearchPanelAction());
+        actions.add(new DeleteNextWordAction());
 
         actionMap = new ActionMapUIResource();
         for (Action a : actions) {
@@ -76,6 +80,8 @@ public class RSTextAreaFactory {
 
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F3,   0),       FindNextAction.findNextAction);
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F3,   shift),   FindNextAction.findPreviousAction);
+
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, defaultModifier), deleteNextWordAction);
 
         UIManager.put("RSyntaxTextAreaUI.inputMap", inputMap);
 


### PR DESCRIPTION
Currently, when you press Ctrl+Del - it deletes the rest of the line - I think it's nicer if it just delete the next word.

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.
